### PR TITLE
Element width bugfix 

### DIFF
--- a/lib/zebra/zpl/label.rb
+++ b/lib/zebra/zpl/label.rb
@@ -36,7 +36,7 @@ module Zebra
       end
 
       def <<(element)
-        element.width = self.width
+        element.width = self.width unless element.width.present?
         elements << element
       end
 


### PR DESCRIPTION
This should resolve Issue #24

Running the snippet from the Issue now will return:

label_fed_number.to_zpl
>>^FWN^CF0,22^CI28^FO0,20^FB200,4,0,L,0^FDFEDERAL RN#90630 ONT. REG.# 34333^FS
label.dump_contents
>> ^XA^LL800^LH0,0^LS10^PW800^PR6^FWN^CF0,22^CI28^FO0,20^FB200,4,0,L,0^FDFEDERAL RN#90630 ONT. REG.# 34333^FS^PQ1^XZ
This PR simply checks to make sure the width of an element isn't present before assigning.