### PR TITLE
Remove hard coded attributes in Text Block

### DIFF
--- a/lib/zebra/zpl/text.rb
+++ b/lib/zebra/zpl/text.rb
@@ -5,7 +5,9 @@ module Zebra
     class Text
       include Printable
 
-      attr_reader :font_size, :font_type, :width
+      class InvalidMaxLinesError < StandardError; end
+
+      attr_reader :font_size, :font_type, :width, :max_lines, :line_spacing, :hanging_indent
 
       def font_size=(f)
         FontSize.validate_font_size f
@@ -18,6 +20,19 @@ module Zebra
         else
           @width = width || 0
         end
+      end
+
+      def max_lines=(value)
+        raise InvalidMaxLinesError unless value.to_i >= 1
+        @max_lines = value || 4
+      end
+
+      def line_spacing=(value)
+        @line_spacing = value || 0
+      end
+
+      def hanging_indent=(value)
+        @hanging_indent = value || 0
       end
 
       def font_type=(type)
@@ -66,7 +81,7 @@ module Zebra
         # "^FO25,25^FB600,100,0,C,0^FDFoo^FS"
 
         # "^CF#{font_type},#{font_size}^FO#{x},#{y}^FB609,4,0,#{justification},0^FD#{data}^FS"
-        "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},4,0,#{justification},0^FD#{data}^FS"
+        "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS"
       end
 
       private

--- a/lib/zebra/zpl/text.rb
+++ b/lib/zebra/zpl/text.rb
@@ -7,7 +7,7 @@ module Zebra
 
       class InvalidMaxLinesError < StandardError; end
 
-      attr_reader :font_size, :font_type, :width, :max_lines, :line_spacing, :hanging_indent
+      attr_reader :font_size, :font_type, :width, :line_spacing, :hanging_indent
 
       def font_size=(f)
         FontSize.validate_font_size f
@@ -24,7 +24,7 @@ module Zebra
 
       def max_lines=(value)
         raise InvalidMaxLinesError unless value.to_i >= 1
-        @max_lines = value || 4
+        @max_lines = value
       end
 
       def line_spacing=(value)
@@ -63,6 +63,10 @@ module Zebra
 
       def print_mode
         @print_mode || PrintMode::NORMAL
+      end
+
+      def max_lines
+        @max_lines || 4
       end
 
       def h_multiplier=(multiplier)


### PR DESCRIPTION
This PR should resolve #28 and add the currently hard coded attributes for the FB. I have kept the default value of 4 for max_lines in case any legacy code was relying on that.

  label = Zebra::Zpl::Label.new(
        :width         => 800,
        :length        => 800,
        :print_speed   => 6,
        :print_density => 5,
        :copies        => 1
      )

 label_fed_number = Zebra::Zpl::Text.new(
        :data           => ("FEDERAL RN#90630 ONT. REG.# 34333"),
        :position       => [200, 600],
        :justification  => Zebra::Zpl::Justification::LEFT,
        :font_size      => Zebra::Zpl::FontSize::SIZE_2,
        :width          => 200,
        :max_lines      => 3,
        :line_spacing   => 3,
        :hanging_indent => 20
      )
label << label_fed_number
label.dump_contents
>>^XA^LL800^LH0,0^LS10^PW800^PR6^FWN^CF0,22^CI28^FO200,600^FB800,3,3,L,20^FDFEDERAL RN#90630 ONT. REG.# 34333^FS^PQ1^XZ